### PR TITLE
Fix(#5): Updated trees sketch to render simultaneously. Dynamic height based on screen

### DIFF
--- a/docs/sketches/trees/trees.html
+++ b/docs/sketches/trees/trees.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>tree</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.6.0/p5.min.js"></script>
+    <script src="../utils.js"></script>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>

--- a/docs/sketches/trees/trees.js
+++ b/docs/sketches/trees/trees.js
@@ -1,20 +1,17 @@
-// Helper function to convert a fractional opacity to a 0–255 value.
-function opacity(val) {
-  return val * 255;
-}
-
-// A simple textured background function that draws random points.
-function textured_background() {
-  let density = 5000;
-  stroke(2, opacity(0.3));
-  strokeWeight(1.5);
-  for (let i = 0; i < density; i++) {
-    point(random(width), random(height));
-  }
-}
-
 // Global constants
-const TRUNK_LENGTH = 60;
+
+let defaultTrunkLength = p5.prototype.map(
+  p5.prototype.windowHeight,
+  761,
+  857,
+  38,
+  60
+);
+const DEFAULT_TRUNK_LENGTH = p5.prototype.constrain(
+  defaultTrunkLength,
+  20,
+  100
+);
 const TRUNK_WIDTH = 10;
 const TRUNK_BASE_OFFSET = 100;
 const TRUNK_OPACITY = opacity(1);
@@ -39,13 +36,7 @@ let lengthSlider, numLevelsSlider;
 let lengthSliderLabel;
 
 // Global variables for fade‑in effect
-let branchBuffer = null;
-let leavesBuffer = null;
-let fadeAlphaBranch = 0;
-let fadeAlphaLeaves = 0;
-let fadingBranch = true;
-let fadingLeaves = false;
-
+let trees = []; // will hold { branchBuffer, leavesBuffer, fadeAlphaBranch, fadeAlphaLeaves, state }
 
 function draw_leaves(lb, x1, y1, x2, y2, num_leaves) {
   lb.push();
@@ -53,8 +44,12 @@ function draw_leaves(lb, x1, y1, x2, y2, num_leaves) {
   lb.fill(193, 18, 31, opacity(0.6));
   for (let i = 1; i <= num_leaves; i++) {
     let t = i / (num_leaves + 1);
-    let x = lb.lerp(x1, x2, t) + lb.random(-LEAF_MAX_DISTANCE_FROM_BRANCH, LEAF_MAX_DISTANCE_FROM_BRANCH);
-    let y = lb.lerp(y1, y2, t) + lb.random(-LEAF_MAX_DISTANCE_FROM_BRANCH, LEAF_MAX_DISTANCE_FROM_BRANCH);
+    let x =
+      lb.lerp(x1, x2, t) +
+      lb.random(-LEAF_MAX_DISTANCE_FROM_BRANCH, LEAF_MAX_DISTANCE_FROM_BRANCH);
+    let y =
+      lb.lerp(y1, y2, t) +
+      lb.random(-LEAF_MAX_DISTANCE_FROM_BRANCH, LEAF_MAX_DISTANCE_FROM_BRANCH);
     let leafW = LEAF_WIDTH + lb.random(-LEAF_WIDTH / 3, LEAF_WIDTH / 3);
     let leafH = LEAF_HEIGHT + lb.random(-LEAF_HEIGHT / 3, LEAF_HEIGHT / 3);
     lb.ellipse(x, y, leafW, leafH);
@@ -66,15 +61,15 @@ function draw_branch(bb, lb, length, angle, width, depth, alpha) {
   bb.strokeWeight(width);
   bb.stroke(47, 0, 0, alpha);
   if (depth === 0) return;
-  
+
   let x_end = bb.cos(angle) * length;
   let y_end = bb.sin(angle) * length;
   bb.line(0, 0, x_end, y_end);
-  
+
   if (depth < NUM_LEVELS - LEAF_START_AFTER_LEVEL) {
     draw_leaves(lb, 0, 0, x_end, y_end, NUM_LEAVES_PER_LEVEL);
   }
-  
+
   bb.translate(x_end, y_end);
   lb.translate(x_end, y_end);
   for (let i = 0; i < NUM_SPLITS; i++) {
@@ -98,8 +93,16 @@ function draw_tree_buffer(bb, lb, x, y) {
   bb.push();
   bb.translate(x, y);
   lb.translate(x, y);
-  let trunk_length = lengthSlider.value()
-  draw_branch(bb, lb, trunk_length, -bb.HALF_PI, TRUNK_WIDTH, NUM_LEVELS, TRUNK_OPACITY);
+  let trunk_length = lengthSlider.value();
+  draw_branch(
+    bb,
+    lb,
+    trunk_length,
+    -bb.HALF_PI,
+    TRUNK_WIDTH,
+    NUM_LEVELS,
+    TRUNK_OPACITY
+  );
   bb.pop();
 }
 
@@ -111,67 +114,72 @@ function setup() {
   createCanvas(windowWidth, windowHeight);
   background(255);
   textured_background();
-  
-  lengthSliderLabel = createDiv('tree size');
-  lengthSliderLabel.class('slider-label');
+
+  lengthSliderLabel = createDiv("tree size");
+  lengthSliderLabel.class("slider-label");
   lengthSliderLabel.position(windowWidth - 105, windowHeight - 50);
-  
-  lengthSlider = createSlider(20, 100, TRUNK_LENGTH, 5);
+
+  lengthSlider = createSlider(20, 100, DEFAULT_TRUNK_LENGTH, 5);
+
   lengthSlider.position(windowWidth - 150, windowHeight - 65);
-  lengthSlider.style('width', '100px');
-  lengthSlider.class('mySlider');
-  lengthSlider.elt.addEventListener('mousedown', (e) => e.stopPropagation());
-  lengthSlider.elt.addEventListener('touchstart', (e) => e.stopPropagation());
-  lengthSlider.elt.addEventListener('touchmove', (e) => e.stopPropagation());
+  lengthSlider.style("width", "100px");
+  lengthSlider.class("mySlider");
+  lengthSlider.elt.addEventListener("mousedown", (e) => e.stopPropagation());
+  lengthSlider.elt.addEventListener("touchstart", (e) => e.stopPropagation());
+  lengthSlider.elt.addEventListener("touchmove", (e) => e.stopPropagation());
 }
 
 function draw() {
-  if (fadingBranch && branchBuffer) {
-    tint(255, fadeAlphaBranch);
-    image(branchBuffer, 0, 0);
-    noTint();
-    fadeAlphaBranch += 8; 
-    if (fadeAlphaBranch >= 255) {
-      image(branchBuffer, 0, 0);
-      fadingBranch = false;
-      branchBuffer = null;
-      fadingLeaves = true;
-      fadeAlphaLeaves = 0;
+  // Animate each tree in parallel
+  for (let t of trees) {
+    if (t.state === "branch") {
+      tint(255, t.fadeAlphaBranch);
+      image(t.branchBuffer, 0, 0);
+      noTint();
+
+      t.fadeAlphaBranch += 8;
+      if (t.fadeAlphaBranch >= 255) {
+        // Branch fade done → lock it and move to leaves
+        image(t.branchBuffer, 0, 0);
+        t.state = "leaves";
+      }
+    } else if (t.state === "leaves") {
+      tint(255, t.fadeAlphaLeaves);
+      image(t.leavesBuffer, 0, 0);
+      noTint();
+
+      t.fadeAlphaLeaves += 0.75;
+      if (t.fadeAlphaLeaves >= 255) {
+        // Leaves fade done → lock them
+        image(t.leavesBuffer, 0, 0);
+        t.state = "done";
+      }
     }
   }
 
-  if (fadingLeaves && leavesBuffer) {
-    tint(255, fadeAlphaLeaves);
-    image(leavesBuffer, 0, 0);
-    noTint();
-    fadeAlphaLeaves += 0.75; 
-    if (fadeAlphaLeaves >= 255) {
-      image(leavesBuffer, 0, 0);
-      fadingLeaves = false;
-      fadeAlphaLeaves = 0;
-      leavesBuffer = null;
-    }
-  }
+  // Remove trees that are fully finished
+  trees = trees.filter((t) => t.state !== "done");
 }
 
 function mousePressed() {
-
   if (mouseButton === RIGHT) {
     let ts = Date.now();
     // Uncomment the following line to save the canvas image:
     // saveCanvas('tree_' + ts, 'png');
   } else {
-    // Instead of drawing the tree immediately on the main canvas,
-    // create an offscreen graphics buffer and draw the tree on it.
+    // create an offscreen graphics buffer and draw the tree on it to animate slowly onto the main canvas
     branchBuffer = createGraphics(windowWidth, windowHeight);
     leavesBuffer = createGraphics(windowWidth, windowHeight);
-    branchBuffer.clear();
-    leavesBuffer.clear();
-    draw_tree_buffer(branchBuffer, leavesBuffer,mouseX, mouseY);
-    fadeAlphaLeaves = 0;
-    fadeAlphaBranch = 0;
-    fadingBranch = true;
-    fadingLeaves = false;
+    draw_tree_buffer(branchBuffer, leavesBuffer, mouseX, mouseY);
+
+    // adding a new tree animation to the queue
+    trees.push({
+      branchBuffer: branchBuffer,
+      leavesBuffer: leavesBuffer,
+      fadeAlphaBranch: 0,
+      fadeAlphaLeaves: 0,
+      state: "branch", // or 'leaves' or 'done'
+    });
   }
 }
 


### PR DESCRIPTION
- Allowed multiple buffers to render arbitrary number of trees simultaneously. 
- Made slider default trunk length to be dynamic. 
- Linting